### PR TITLE
Fix RTL support

### DIFF
--- a/src/components/Pega_Extensions_NetworkDiagram/index.tsx
+++ b/src/components/Pega_Extensions_NetworkDiagram/index.tsx
@@ -181,6 +181,7 @@ export default function PegaExtensionsNetworkDiagram(props: NetworkDiagramProps)
         <CardContent>
           <StyledPegaExtensionsNetworkDiagram height={height} theme={theme}>
             <ReactFlow
+              dir='ltr'
               nodes={nodes}
               edges={edges}
               onNodesChange={onNodesChange}


### PR DESCRIPTION
Fixes #19

Enforces `dir="ltr"` on ReactFlow container for a graceful fallback in RTL direction mode.