### PR TITLE
Signature component style issue

### DIFF
--- a/src/components/Pega_Extensions_SignatureCapture/index.tsx
+++ b/src/components/Pega_Extensions_SignatureCapture/index.tsx
@@ -7,12 +7,15 @@ import {
   Flex,
   FormField,
   FormControl,
-  Configuration,
-  useTheme
+  Configuration
 } from '@pega/cosmos-react-core';
 import SignaturePad from 'signature_pad';
 import Signature from './Signature';
-import { StyledSignatureContent, StyledSignatureReadOnlyContent } from './styles';
+import {
+  StyledButtonsWrapper,
+  StyledSignatureContent,
+  StyledSignatureReadOnlyContent
+} from './styles';
 
 type SignatureCaptureProps = {
   getPConnect: any;
@@ -43,7 +46,6 @@ const PegaExtensionsSignatureCapture = (props: SignatureCaptureProps) => {
   } = props;
 
   const ref = useRef<SignaturePad>();
-  const theme = useTheme();
   const pConn = getPConnect();
   const actions = pConn.getActionsApi();
   const propName = pConn.getStateProps().value;
@@ -71,7 +73,7 @@ const PegaExtensionsSignatureCapture = (props: SignatureCaptureProps) => {
   }, [status, validatemessage]);
 
   const displayComp = value ? (
-    <StyledSignatureReadOnlyContent theme={theme}>
+    <StyledSignatureReadOnlyContent>
       <Image alt={label} src={value} />
     </StyledSignatureReadOnlyContent>
   ) : null;
@@ -153,12 +155,21 @@ const PegaExtensionsSignatureCapture = (props: SignatureCaptureProps) => {
                     }}
                     onEndStroke={onEndStroke}
                   />
-                  <Flex container={{ direction: 'row', justify: 'between' }}>
-                    <Button className='accept' onClick={handleAccept} disabled={!hasValueChanged}>
-                      Accept
-                    </Button>
-                    <Button className='clear' onClick={handleCLear}>
+                  <Flex
+                    as={StyledButtonsWrapper}
+                    container={{ direction: 'row', justify: 'between', pad: [1] }}
+                  >
+                    <Button compact className='clear' onClick={handleCLear}>
                       Clear
+                    </Button>
+                    <Button
+                      compact
+                      variant='primary'
+                      className='accept'
+                      onClick={handleAccept}
+                      disabled={!hasValueChanged}
+                    >
+                      Accept
                     </Button>
                   </Flex>
                 </>

--- a/src/components/Pega_Extensions_SignatureCapture/styles.ts
+++ b/src/components/Pega_Extensions_SignatureCapture/styles.ts
@@ -1,21 +1,19 @@
-import { type themeDefinition } from '@pega/cosmos-react-core';
+import { Flex, defaultThemeProp } from '@pega/cosmos-react-core';
 import styled, { css } from 'styled-components';
 
-export const StyledSignatureContent = styled.div(() => {
+export const StyledSignatureContent = styled.div``;
+export const StyledButtonsWrapper = styled(Flex)(({ theme }) => {
   return css`
-    & button {
-      border-radius: 0;
-      border-bottom: none;
-      padding: 0.25rem 0.5rem;
-    }
+    padding: ${theme.base.spacing};
+    border-top: 0.0625rem dashed ${theme.base.palette['border-line']};
   `;
 });
+StyledButtonsWrapper.defaultProps = defaultThemeProp;
 
-export const StyledSignatureReadOnlyContent = styled.div(
-  ({ theme }: { theme: typeof themeDefinition }) => {
-    return css`
-      max-width: 40ch;
-      border: 0.0625rem solid ${theme.base.palette['border-line']};
-    `;
-  }
-);
+export const StyledSignatureReadOnlyContent = styled.div(({ theme }) => {
+  return css`
+    max-width: 40ch;
+    border: 0.0625rem solid ${theme.base.palette['border-line']};
+  `;
+});
+StyledSignatureReadOnlyContent.defaultProps = defaultThemeProp;


### PR DESCRIPTION
Fixes #30

Changed styling of the component a bit to make it aligned with Design System.
1. Added dotted border to separate drawing area and clickable actions. I found it useful to avoid situation where drawing fails when started outside of signature component (empty whitespace between two buttons).
2. Using compact button with padding to Button container, to save space and avoid bleed
3. Reverse order of button, in general - we are keeping positive action in the right and cancellation/destructive action in left. Also changed button variants secondary/primary accordingly.

![Screenshot 2024-03-16 at 9 24 56 AM](https://github.com/pegasystems/constellation-ui-gallery/assets/11829883/ea49fd83-2d84-4369-87bf-a1fe5f196bf8)


Happy to be course corrected if anyone thinks otherwise.