### PR TITLE
Improve card gallery to work in a dashboard page 

### DIFF
--- a/src/components/Pega_Extensions_CardGallery/Docs.mdx
+++ b/src/components/Pega_Extensions_CardGallery/Docs.mdx
@@ -11,6 +11,9 @@ Each card will represent a case or data object. The list of cards to render is p
 - Ability to create a new card through an action in the header by setting the 'createClassname' property
 - Tasks are rendered using a details view and not hardcoded inside the component, which allows to use visible when and other features to personalize the content of the card
 - Cards can be rendered horizontally (from left to right) or vertically (up / down). The vertically rendering is similar to a masonry layout and will optimize the available space.
+- The Card Gallery component is also compatible with dashboard and will listen to filter changes if the property 'useInDashboard' is set
+
+Note: if 'useInDashboard' is true, the data page must be of type queryable and must be sourced from a Report Definition.
 
 <Story of={DemoStories.Default} />
 

--- a/src/components/Pega_Extensions_CardGallery/Task.tsx
+++ b/src/components/Pega_Extensions_CardGallery/Task.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from 'react';
 import {
   Progress,
   Button,
@@ -15,29 +14,16 @@ export type TaskProps = {
   title: string;
   insKey: string;
   status: string;
-  classname: string;
-  id: string;
   details?: any;
-  getDetails: any;
   editTask: any;
 };
 
 export const Task = (props: TaskProps) => {
-  const { insKey, classname, status, id, title, details, getDetails, editTask } = props;
-  const [newdetails, setDetails] = useState<any>(details);
+  const { insKey, status, title, details, editTask } = props;
   const theme = useTheme();
   const onEdit = () => {
     editTask(insKey);
   };
-
-  const addDetails = async () => {
-    setDetails(await getDetails(id, classname));
-  };
-
-  useEffect(() => {
-    addDetails();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   return (
     <StyledCardContent theme={theme}>
@@ -54,7 +40,7 @@ export const Task = (props: TaskProps) => {
           <Text variant='h3'>{title}</Text>
         </CardHeader>
         <CardContent>
-          {newdetails || <Progress placement='inline' message='Loading content...' />}
+          {details || <Progress placement='inline' message='Loading content...' />}
         </CardContent>
       </Card>
     </StyledCardContent>

--- a/src/components/Pega_Extensions_CardGallery/config.json
+++ b/src/components/Pega_Extensions_CardGallery/config.json
@@ -16,6 +16,12 @@
       "format": "TEXT"
     },
     {
+      "name": "useInDashboard",
+      "label": "Set to true if you are using in a dashboard - use a queryable data page",
+      "format": "BOOLEAN",
+      "defaultValue": false
+    },
+    {
       "name": "dataPage",
       "label": "List Data Page name to get all objects",
       "format": "TEXT",

--- a/src/components/Pega_Extensions_CardGallery/demo.stories.tsx
+++ b/src/components/Pega_Extensions_CardGallery/demo.stories.tsx
@@ -260,6 +260,14 @@ const setPCore = (args: any) => {
         }
       };
     },
+    getConstants: () => {
+      return {
+        PUB_SUB_EVENTS: {
+          EVENT_DASHBOARD_FILTER_CHANGE: 'EVENT_DASHBOARD_FILTER_CHANGE',
+          EVENT_DASHBOARD_FILTER_CLEAR_ALL: 'EVENT_DASHBOARD_FILTER_CLEAR_ALL'
+        }
+      };
+    },
     getDataApiUtils: () => {
       return {
         getCaseEditLock: () => {
@@ -357,6 +365,7 @@ export const Default: Story = {
     heading: 'Card Gallery',
     createClassname: 'Work-UserStory',
     dataPage: '',
+    useInDashboard: false,
     minWidth: '400px',
     rendering: 'horizontal',
     detailsDataPage: '',

--- a/src/components/Pega_Extensions_CardGallery/utils.ts
+++ b/src/components/Pega_Extensions_CardGallery/utils.ts
@@ -46,3 +46,20 @@ export const loadDetails = async (props: loadDetailsProps) => {
     });
   return myElem;
 };
+
+export const getFilters = (filters: any) => {
+  const tmpFilters = Object.entries(filters).map((i: any) => {
+    return { ...i[1].condition, ignoreCase: true };
+  });
+  if (tmpFilters.length === 0) return null;
+  let logic = '';
+  const filterConditions: any = {};
+  for (let i = 0; i < tmpFilters.length; i += 1) {
+    logic = `${logic + (i > 0 ? ' AND ' : '')}T${i + 1}`;
+    filterConditions[`T${i + 1}`] = tmpFilters[i];
+  }
+  return {
+    logic,
+    filterConditions
+  };
+};


### PR DESCRIPTION
- add new config boolean to enable support for dashboard page - will require the DP to be queryable
- Fix the Task component to no longer getDetail - this was already done in the parent component
- Listen to changes from the dashboard and pass filter to the DP
- Add errorstate and emptystate