### PR TITLE
Japanese calendar conversion

### DIFF
--- a/src/components/Pega_Extensions_JapaneseInput/Docs.mdx
+++ b/src/components/Pega_Extensions_JapaneseInput/Docs.mdx
@@ -13,6 +13,10 @@ Japanese input component has the following features.
   Japanese has two types of characters, Hiragana and Katakana, which correspond one-to-one. Hiragana input is converted to Katakana.
 - Full-width to Half-width  
   In Japanese, characters are generally handled as multi-byte full-width characters rather than single-byte half-width characters, and for this reason Japanese keyboards have a function to input characters in full-width. Some full-width characters have the same meaning in half-width, and these are converted from full-width to half-width.
+- Japanese Era to Gregorian  
+  Converts "Wareki" (Japanese calendar dates) to "Seireki" (Gregorian calendar dates). For example, "平成元年1月" will be converted to "1989年1月".
+- Gregorian to Japanese Era  
+  Converts "Seireki" (Gregorian calendar dates) to "Wareki" (Japanese calendar dates). For example, "1989年1月" will be converted to "平成元年1月".
 
 <Primary />
 

--- a/src/components/Pega_Extensions_JapaneseInput/config.json
+++ b/src/components/Pega_Extensions_JapaneseInput/config.json
@@ -79,6 +79,16 @@
           "name": "lowerToUpper",
           "label": "Lowercase to Uppercase",
           "format": "BOOLEAN"
+        },
+        {
+          "name": "japaneseEraToGregorian",
+          "label": "Japanese Era to Gregorian",
+          "format": "BOOLEAN"
+        },
+        {
+          "name": "gregorianToJapaneseEra",
+          "label": "Gregorian to Japanese Era",
+          "format": "BOOLEAN"
         }
       ]
     },

--- a/src/components/Pega_Extensions_JapaneseInput/demo.stories.tsx
+++ b/src/components/Pega_Extensions_JapaneseInput/demo.stories.tsx
@@ -80,6 +80,8 @@ export const Default: Story = {
     errorMessage: '',
     hiraganaToKatakana: false,
     fullToHalf: false,
-    lowerToUpper: false
+    lowerToUpper: false,
+    japaneseEraToGregorian: false,
+    gregorianToJapaneseEra: false,
   }
 };

--- a/src/components/Pega_Extensions_JapaneseInput/index.tsx
+++ b/src/components/Pega_Extensions_JapaneseInput/index.tsx
@@ -14,7 +14,12 @@ import {
 } from '@pega/cosmos-react-core';
 import '../create-nonce';
 import type { FieldValueVariant } from '@pega/cosmos-react-core/lib/components/FieldValueList/FieldValueList';
-import { convertHiraganaToKatakana, fullWidthToHalfWidth } from './utils';
+import {
+  convertHiraganaToKatakana,
+  fullWidthToHalfWidth,
+  convertGregorianToJapaneseEra,
+  convertJapaneseEraToGregorian
+} from './utils';
 
 enum DisplayMode {
   DisplayOnly = 'DISPLAY_ONLY',
@@ -30,6 +35,8 @@ export interface PegaExtensionsJapaneseInputProps extends InputProps, TestIdProp
   hiraganaToKatakana: boolean;
   fullToHalf: boolean;
   lowerToUpper: boolean;
+  japaneseEraToGregorian: boolean;
+  gregorianToJapaneseEra: boolean;
   label: string;
   getPConnect: any;
   errorMessage: string;
@@ -63,6 +70,8 @@ export const PegaExtensionsJapaneseInput: FC<PegaExtensionsJapaneseInputProps> =
   hiraganaToKatakana = false,
   fullToHalf = false,
   lowerToUpper = false,
+  japaneseEraToGregorian = false,
+  gregorianToJapaneseEra = false,
   ...restProps
 }: PegaExtensionsJapaneseInputProps) => {
   const pConn = getPConnect();
@@ -142,6 +151,11 @@ export const PegaExtensionsJapaneseInput: FC<PegaExtensionsJapaneseInputProps> =
     }
     if (lowerToUpper) {
       newValue = newValue.toUpperCase();
+    }
+    if (japaneseEraToGregorian && /^(令和|平成|昭和|大正|明治)/.test(newValue)) {
+      newValue = convertJapaneseEraToGregorian(newValue);
+    } else if (gregorianToJapaneseEra && /^([\d０-９]{3,4})(年)?/.test(newValue)) {
+      newValue = convertGregorianToJapaneseEra(newValue);
     }
     if (event.target.value !== newValue) {
       setInputValue(newValue);


### PR DESCRIPTION
Add Japanese input with the following 3 features.
- Japanese Era to Gregorian  
  Converts "Wareki" (Japanese calendar dates) to "Seireki" (Gregorian calendar dates). For example, "平成元年1月" will be converted to "1989年1月".
- Gregorian to Japanese Era  
  Converts "Seireki" (Gregorian calendar dates) to "Wareki" (Japanese calendar dates). For example, "1989年1月" will be converted to "平成元年1月".