### PR TITLE
Disable image pasting

### DIFF
--- a/src/components/Pega_Extensions_SecureRichText/index.tsx
+++ b/src/components/Pega_Extensions_SecureRichText/index.tsx
@@ -298,6 +298,7 @@ export const PegaExtensionsSecureRichText = (props: RichTextProps) => {
           onBlur={handleBlur}
           onFocus={handleFocus}
           onInit={onInit}
+          initOptions={{ pasteDataImages: false }}
         />
         {showWordCounter && (
           <div


### PR DESCRIPTION
As Secure Rich Text Editor removed the ability to insert images, there is an issue on pasting images in the editor. This is fixed in the branch.