### PR TITLE
Prevent false error status in Japanese Input when errorMessage is undefined

### DIFF
--- a/src/components/Pega_Extensions_JapaneseInput/index.tsx
+++ b/src/components/Pega_Extensions_JapaneseInput/index.tsx
@@ -51,7 +51,7 @@ export const getJapaneseInputTestIds = createTestIds('japanese-input', [] as con
 export const PegaExtensionsJapaneseInput: FC<PegaExtensionsJapaneseInputProps> = ({
   testId,
   getPConnect,
-  errorMessage,
+  errorMessage = '',
   displayMode,
   value,
   label,


### PR DESCRIPTION
Fixed a bug where the UI always showed the error status when `errorMessage` was `undefined` by assigning it the default value `''`.