### PR TITLE
Prevent false error status in Japanese Input when errorMessage is undefined

### DIFF
--- a/src/components/Pega_Extensions_JapaneseInput/index.tsx
+++ b/src/components/Pega_Extensions_JapaneseInput/index.tsx
@@ -51,7 +51,7 @@ export const getJapaneseInputTestIds = createTestIds('japanese-input', [] as con
 export const PegaExtensionsJapaneseInput: FC<PegaExtensionsJapaneseInputProps> = ({
   testId,
   getPConnect,
-  errorMessage,
+  errorMessage = '',
   displayMode,
   value,
   label,


### PR DESCRIPTION
Same fix as https://github.com/pegasystems/constellation-ui-gallery/pull/181 to the release/2.0.