### PR TITLE
chore(DisplayAttachments): add component count publishing and iconName for mounting

### DIFF
--- a/src/components/Pega_Extensions_DisplayAttachments/config.json
+++ b/src/components/Pega_Extensions_DisplayAttachments/config.json
@@ -38,7 +38,7 @@
       "visibility": "($this.useAttachmentEndpoint = false)"
     },
     {
-      "name": "icon",
+      "name": "iconName",
       "label": "Icon",
       "format": "SELECT",
       "defaultValue": "clipboard",
@@ -83,6 +83,7 @@
     "heading": "List of attachments",
     "categories": "",
     "dataPage": "",
+    "iconName": "clipboard",
     "useAttachmentEndpoint": true,
     "enableDownloadAll": false
   }

--- a/src/components/Pega_Extensions_DisplayAttachments/demo.stories.tsx
+++ b/src/components/Pega_Extensions_DisplayAttachments/demo.stories.tsx
@@ -279,6 +279,13 @@ const setPCore = () => {
         },
       };
     },
+    getPubSubUtils: () => {
+      return {
+        publish: () => {
+          /* nothing */
+        },
+      };
+    },
   };
 };
 
@@ -314,7 +321,7 @@ export const Default: Story = DisplayAttachmentsDemo({
   enableDownloadAll: false,
   dataPage: 'D_AttachmentListRO',
   displayFormat: 'list',
-  icon: 'clipboard',
+  iconName: 'clipboard',
 });
 
 export const Tiles: Story = DisplayAttachmentsDemo({
@@ -325,5 +332,5 @@ export const Tiles: Story = DisplayAttachmentsDemo({
   enableDownloadAll: true,
   dataPage: 'D_AttachmentListRO',
   displayFormat: 'tiles',
-  icon: 'clipboard',
+  iconName: 'clipboard',
 });


### PR DESCRIPTION
- Publish component count when attachment list updates
- Use `iconName` for component mounting with existing OOTB UI components