### PR TITLE
Align widgets `iconName` with OOTB components

### DIFF
--- a/src/components/Pega_Extensions_CaseHierarchy/config.json
+++ b/src/components/Pega_Extensions_CaseHierarchy/config.json
@@ -16,6 +16,22 @@
       "format": "TEXT"
     },
     {
+      "name": "iconName",
+      "label": "Icon",
+      "format": "SELECT",
+      "defaultValue": "folder-nested",
+      "source": [
+        {
+          "key": "folder-nested",
+          "value": "folder-nested"
+        },
+        {
+          "key": "folders",
+          "value": "folders"
+        }
+      ]
+    },
+    {
       "name": "dataPage",
       "label": "Data Page name",
       "format": "TEXT"
@@ -28,6 +44,7 @@
   ],
   "defaultConfig": {
     "heading": "Case Hierarchy",
-    "showParent": false
+    "showParent": false,
+    "iconName": "folder-nested"
   }
 }

--- a/src/components/Pega_Extensions_CaseHierarchy/index.tsx
+++ b/src/components/Pega_Extensions_CaseHierarchy/index.tsx
@@ -7,8 +7,9 @@ import '../create-nonce';
 
 import * as caretRightIcon from '@pega/cosmos-react-core/lib/components/Icon/icons/caret-right.icon';
 import * as FolderNestedIcon from '@pega/cosmos-react-core/lib/components/Icon/icons/folder-nested.icon';
+import * as FoldersIcon from '@pega/cosmos-react-core/lib/components/Icon/icons/folders.icon';
 
-registerIcon(caretRightIcon, FolderNestedIcon);
+registerIcon(caretRightIcon, FolderNestedIcon, FoldersIcon);
 type CaseHierarchyProps = {
   heading?: string;
   dataPage: string;

--- a/src/components/Pega_Extensions_DisplayAttachments/index.tsx
+++ b/src/components/Pega_Extensions_DisplayAttachments/index.tsx
@@ -193,9 +193,10 @@ export const PegaExtensionsDisplayAttachments = (props: UtilityListProps) => {
       });
       setFiles(listOfFiles);
       setAttachments(listOfAttachments);
+      publishAttachmentsUpdated(listOfAttachments?.length ?? 0);
       setLoading(false);
     },
-    [categories, getPConnect, useAttachmentEndpoint, useLightBox],
+    [categories, getPConnect, useAttachmentEndpoint, useLightBox, publishAttachmentsUpdated],
   );
 
   const initialLoad = useCallback(() => {
@@ -241,7 +242,6 @@ export const PegaExtensionsDisplayAttachments = (props: UtilityListProps) => {
       () => {
         /* If an attachment is added- force a reload of the events */
         initialLoad();
-        publishAttachmentsUpdated(attachments?.length ?? 0);
       },
       getPConnect().getContextName(),
     );
@@ -249,21 +249,11 @@ export const PegaExtensionsDisplayAttachments = (props: UtilityListProps) => {
       (window as any).PCore.getMessagingServiceManager().unsubscribe(attachSubId);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    categories,
-    useLightBox,
-    useAttachmentEndpoint,
-    enableDownloadAll,
-    getPConnect,
-    initialLoad,
-    publishAttachmentsUpdated,
-  ]);
+  }, [categories, useLightBox, useAttachmentEndpoint, enableDownloadAll, getPConnect, initialLoad]);
 
   useEffect(() => {
     initialLoad();
-    publishAttachmentsUpdated(attachments?.length ?? 0);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [categories, useLightBox, useAttachmentEndpoint, enableDownloadAll, initialLoad, publishAttachmentsUpdated]);
+  }, [categories, useLightBox, useAttachmentEndpoint, enableDownloadAll, initialLoad]);
 
   return (
     <>

--- a/src/components/Pega_Extensions_OAuthConnect/config.json
+++ b/src/components/Pega_Extensions_OAuthConnect/config.json
@@ -43,6 +43,22 @@
       "visibility": "showDisconnect = true"
     },
     {
+      "name": "iconName",
+      "label": "Icon",
+      "format": "SELECT",
+      "defaultValue": "node",
+      "source": [
+        {
+          "key": "node",
+          "value": "node"
+        },
+        {
+          "key": "chain",
+          "value": "chain"
+        }
+      ]
+    },
+    {
       "label": "Conditions",
       "format": "GROUP",
       "properties": [

--- a/src/components/Pega_Extensions_OAuthConnect/index.tsx
+++ b/src/components/Pega_Extensions_OAuthConnect/index.tsx
@@ -13,8 +13,9 @@ import { StyledSummaryListHeader, StyledSummaryListContent } from './styles';
 import '../create-nonce';
 
 import * as NodeIcon from '@pega/cosmos-react-core/lib/components/Icon/icons/node.icon';
+import * as ChainIcon from '@pega/cosmos-react-core/lib/components/Icon/icons/chain.icon';
 
-registerIcon(NodeIcon);
+registerIcon(NodeIcon, ChainIcon);
 
 export type OAuthConnectProps = {
   heading?: string;

--- a/src/components/Pega_Extensions_UtilityList/config.json
+++ b/src/components/Pega_Extensions_UtilityList/config.json
@@ -26,7 +26,7 @@
       "format": "BOOLEAN"
     },
     {
-      "name": "icon",
+      "name": "iconName",
       "label": "Icon",
       "format": "SELECT",
       "defaultValue": "clipboard",
@@ -63,6 +63,7 @@
   ],
   "defaultConfig": {
     "heading": "List of objects",
-    "setCaseID": false
+    "setCaseID": false,
+    "iconName": "clipboard"
   }
 }

--- a/src/components/Pega_Extensions_UtilityList/demo.stories.tsx
+++ b/src/components/Pega_Extensions_UtilityList/demo.stories.tsx
@@ -121,6 +121,13 @@ const setPCore = () => {
         },
       };
     },
+    getPubSubUtils: () => {
+      return {
+        publish: () => {
+          /* nothing */
+        },
+      };
+    },
   };
 };
 
@@ -141,7 +148,7 @@ export const Default: Story = {
   },
   args: {
     heading: 'List of objects',
-    icon: 'clipboard',
+    iconName: 'clipboard',
     primaryField: 'pyLabel',
     secondaryFields: 'pyID,pxCreateDateTime,pxCreateOpName',
     secondaryFieldTypes: 'string,date,string',

--- a/src/components/Pega_Extensions_UtilityList/index.tsx
+++ b/src/components/Pega_Extensions_UtilityList/index.tsx
@@ -19,7 +19,7 @@ import '../create-nonce';
 
 type UtilityListProps = {
   heading?: string;
-  icon: 'information' | 'polaris' | 'clipboard';
+  iconName: 'information' | 'polaris' | 'clipboard';
   dataPage: string;
   setCaseID: boolean;
   primaryField: string;
@@ -50,7 +50,7 @@ const ViewAllModal = ({
 export const PegaExtensionsUtilityList = (props: UtilityListProps) => {
   const {
     heading = 'List of objects',
-    icon = 'clipboard',
+    iconName = 'clipboard',
     primaryField,
     secondaryFields = '',
     secondaryFieldTypes = '',
@@ -62,6 +62,15 @@ export const PegaExtensionsUtilityList = (props: UtilityListProps) => {
   const [objects, setObjects] = useState<Array<SummaryListItem>>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const viewAllModalRef = useRef<ModalMethods<any>>();
+  const caseID = getPConnect().getValue((window as any).PCore.getConstants().CASE_INFO.CASE_INFO_ID);
+
+  const publishUtilityUpdated = (count: any) => {
+    (window as any).PCore.getPubSubUtils().publish('WidgetUpdated', {
+      widget: 'PEGA_EXTENSIONS_UTILITYLIST',
+      count,
+      caseID,
+    });
+  };
 
   const loadObjects = (data: Array<any>) => {
     const tmpObjects: Array<SummaryListItem> = [];
@@ -94,6 +103,7 @@ export const PegaExtensionsUtilityList = (props: UtilityListProps) => {
       });
     });
     setObjects(tmpObjects);
+    publishUtilityUpdated(tmpObjects?.length ?? 0);
     setLoading(false);
   };
 
@@ -126,7 +136,7 @@ export const PegaExtensionsUtilityList = (props: UtilityListProps) => {
       <SummaryList
         name={heading}
         headingTag='h3'
-        icon={icon}
+        icon={iconName}
         count={loading ? undefined : objects.length}
         items={objects?.slice(0, 3)}
         loading={loading}


### PR DESCRIPTION
- Update widget with subtype as `Case` with corresponding `iconName`
- fix(DisplayAttachments): component count stuck at zero 
- chore(UtilityList): publish count and add `iconName`
- chore(OAuthConnect):  add `iconName`
- chore(CaseHierarchy):  add `iconName`