### PR TITLE
feat: add Pega_Extensions_PageListSwiper component

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -1,0 +1,136 @@
+# Constellation UI Gallery — Overview
+
+## Overview
+
+The **Constellation DX Components UI Gallery** is an open-source collection of ready-to-use, customizable UI components built for the **Pega Platform** using its **Constellation architecture**.
+
+Constellation's flexible architecture empowers advanced front-end developers (with ReactJS and web technology expertise) to extend the platform by programmatically combining core Constellation presentational components and leveraging the Constellation DX API. The components built this way are called **"Constellation DX Components"**.
+
+This gallery serves as:
+- A **reference library** of community-built, production-ready custom components.
+- A **learning resource** offering source code, best practices, and a solid foundation for building your own components.
+- A **starting point** you can fork, adapt, and extend for your specific business needs.
+
+A live demo is available at [pegasystems.github.io/constellation-ui-gallery](https://pegasystems.github.io/constellation-ui-gallery/).
+
+### How It Works
+
+Each Constellation DX Component is built using a standard front-end development process (TypeScript + React). The compiled component is uploaded to the Pega Platform and stored as a **Rule-UI-Component**, which can then be authored in App Studio and configured into a view.
+
+### Pega Platform Compatibility
+
+| Gallery Version | Branch         | Pega Platform |
+|-----------------|----------------|---------------|
+| 1.x             | release/1.x.x  | Pega '23      |
+| 2.x             | release/2.0    | Pega '24.1    |
+| 3.x             | release/3.0    | Pega '24.2    |
+| 4.x             | master         | Pega '25.1    |
+
+### Deployment Options
+
+Pre-built components are distributed as RAP files (importable into Pega):
+- **ConstellationUIGallery_x_x_x.zip** — Full standalone demo app ("Computerland") showcasing all components.
+- **ConstellationUIGallery_x_x_x_COMPONENTS_ONLY.zip** — Only the Rule-UI-Component rules, without the demo app.
+
+### Tech Stack
+
+- **React** (functional components)
+- **TypeScript**
+- **Storybook** (component development and preview)
+- **Jest** (unit testing)
+- **Playwright** (end-to-end testing)
+- **ESLint** (linting)
+
+---
+
+## Components
+
+The gallery contains **53 custom components** organized under `src/components/`. Each component follows the `Pega_Extensions_` naming convention and is self-contained with its own source, stories, and tests.
+
+### Input Components
+
+| Component | Description |
+|-----------|-------------|
+| `Pega_Extensions_BannerInput` | Displays an editable banner with input support |
+| `Pega_Extensions_CheckboxRow` | Renders a checkbox as a styled row item |
+| `Pega_Extensions_CheckboxTrigger` | Checkbox that triggers conditional logic |
+| `Pega_Extensions_DateInput` | Custom date picker input field |
+| `Pega_Extensions_JapaneseInput` | Input field with Japanese IME support |
+| `Pega_Extensions_MarkdownInput` | Rich-text input using Markdown syntax |
+| `Pega_Extensions_MaskedInput` | Input field with masked/formatted entry (e.g. phone, SSN) |
+| `Pega_Extensions_PasswordInput` | Secure password entry with visibility toggle |
+| `Pega_Extensions_RangeSlider` | Dual-handle range slider input |
+| `Pega_Extensions_StarRatingInput` | Star-based rating input |
+| `Pega_Extensions_Toggle` | Toggle switch input |
+
+### Display / Visualization Components
+
+| Component | Description |
+|-----------|-------------|
+| `Pega_Extensions_Banner` | Static informational banner display |
+| `Pega_Extensions_BarCode` | Renders a scannable barcode |
+| `Pega_Extensions_GanttChart` | Project timeline Gantt chart |
+| `Pega_Extensions_ImageCarousel` | Slideshow carousel for images |
+| `Pega_Extensions_ImageMagnify` | Zoomable image magnifier |
+| `Pega_Extensions_Map` | Embedded map view |
+| `Pega_Extensions_Meter` | Visual meter/progress indicator |
+| `Pega_Extensions_NetworkDiagram` | Interactive network/graph diagram |
+| `Pega_Extensions_QRCode` | QR code generator |
+| `Pega_Extensions_StatusBadge` | Color-coded status badge |
+| `Pega_Extensions_TrendDisplay` | Trend line or sparkline visualization |
+
+### Layout Components
+
+| Component | Description |
+|-----------|-------------|
+| `Pega_Extensions_CompareTableLayout` | Side-by-side comparison table layout |
+| `Pega_Extensions_DynamicTemplate` | Dynamically renders configurable templates |
+| `Pega_Extensions_EditableTableLayout` | Inline-editable data table layout |
+| `Pega_Extensions_FieldGroupAsRow` | Renders a field group horizontally as a row |
+| `Pega_Extensions_FormFullWidth` | Full-width form layout container |
+| `Pega_Extensions_FormWithVerticalStepper` | Multi-step form with a vertical stepper |
+| `Pega_Extensions_JawLayout` | Custom JAW (Just-Another-Widget) layout |
+| `Pega_Extensions_RatingLayout` | Layout optimized for rating/review display |
+| `Pega_Extensions_DynamicHierarchicalForm` | Hierarchical form with dynamic nesting |
+| `Pega_Extensions_HierarchicalFormAsTasks` | Renders a hierarchical form as a task list |
+
+### Productivity / Workflow Components
+
+| Component | Description |
+|-----------|-------------|
+| `Pega_Extensions_ActionableButton` | Button with configurable action triggers |
+| `Pega_Extensions_AutoSave` | Automatically saves form data at intervals |
+| `Pega_Extensions_CaseLauncher` | Launches a new Pega case from within a view |
+| `Pega_Extensions_CaseReference` | Displays and links to a referenced case |
+| `Pega_Extensions_KanbanBoard` | Drag-and-drop Kanban board |
+| `Pega_Extensions_OrgBuilder` | Interactive organizational chart builder |
+| `Pega_Extensions_Scheduler` | Calendar-based scheduler/event planner |
+| `Pega_Extensions_Shortcuts` | Keyboard shortcut manager |
+| `Pega_Extensions_TaskList` | Checklist-style task manager |
+| `Pega_Extensions_CPQTree` | Configure-Price-Quote tree selector |
+
+### Media & Capture Components
+
+| Component | Description |
+|-----------|-------------|
+| `Pega_Extensions_CameraCapture` | Captures photos from device camera |
+| `Pega_Extensions_DisplayAttachments` | Displays file attachments inline |
+| `Pega_Extensions_DisplayPDF` | Embeds and renders PDF documents |
+| `Pega_Extensions_SignatureCapture` | Canvas-based handwritten signature input |
+
+### Utility / Integration Components
+
+| Component | Description |
+|-----------|-------------|
+| `Pega_Extensions_CardGallery` | Card grid gallery layout |
+| `Pega_Extensions_ChatGenAI` | Conversational GenAI chat interface |
+| `Pega_Extensions_IframeWrapper` | Embeds external content in an iframe |
+| `Pega_Extensions_LangSwitch` | Language/locale switcher |
+| `Pega_Extensions_OAuthConnect` | OAuth 2.0 connection helper |
+| `Pega_Extensions_SecureRichText` | Sanitized rich-text display (prevents XSS) |
+| `Pega_Extensions_Calendar` | Full calendar view integration |
+| `Pega_Extensions_UtilityList` | Utility menu/list component |
+
+---
+
+> **Note:** Some components require additional setup in your Pega application (e.g., data pages, activities, or classes) to function fully at runtime. If using the Components Only RAP, these supporting rules must be recreated manually.

--- a/context.md
+++ b/context.md
@@ -1,0 +1,124 @@
+# Session Context — Pega_Extensions_PageListSwiper
+
+## What was built
+
+A new custom Cosmos UI component called **`Pega_Extensions_PageListSwiper`** was added to the
+`constellation-ui-gallery` project. It renders a pagelist property (a list of Pega page objects)
+one profile at a time, allowing a user to Accept or Reject each entry — the primary use-case being
+a doctor/provider selection workflow.
+
+---
+
+## Files created / modified
+
+| File | Status | Description |
+|------|--------|-------------|
+| `src/components/Pega_Extensions_PageListSwiper/index.tsx` | Created | Main component logic |
+| `src/components/Pega_Extensions_PageListSwiper/demo.stories.tsx` | Created | Storybook story with 5 doctor profiles |
+| `src/components/Pega_Extensions_PageListSwiper/styles.ts` | Created | Styled-components CSS |
+| `src/components/Pega_Extensions_PageListSwiper/config.json` | Created | Pega Designer metadata |
+| `src/components/Pega_Extensions_PageListSwiper/Docs.mdx` | Created | Storybook documentation |
+| `src/components/Pega_Extensions_Map/demo.stories.tsx` | Modified | Offline guard — skips ArcGIS CDN when no API key |
+| `OVERVIEW.md` | Created | Repo-level documentation overview |
+
+---
+
+## Component architecture
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `getPConnect` | `any` | — | Pega connector (required) |
+| `heading` | `string` | `'Review Profiles'` | Card heading |
+| `acceptLabel` | `string` | `'Accept'` | Accept button label |
+| `rejectLabel` | `string` | `'Reject'` | Reject button label |
+| `completionMessage` | `string` | `'All profiles reviewed'` | Banner when all rejected |
+| `acceptProperty` | `string` | `'acceptProvider'` | Property name on each page object to write the yes/no decision |
+
+### State
+
+| State | Type | Purpose |
+|-------|------|---------|
+| `fields` | `FieldDef[]` | Parallel arrays of field values extracted from the region metadata |
+| `embedDataRef` | `string` | Page list name (e.g. `Doctors`) used in `pageReference` for PCore calls |
+| `currentIndex` | `number` | Index of the doctor card currently displayed |
+| `decisions` | `Record<number, 'accepted'\|'rejected'>` | Per-index decision map |
+| `acceptedIndex` | `number \| null` | Index of the currently accepted doctor; drives nav cap |
+| `loading` | `boolean` | True while metadata is being parsed |
+
+### Key derived values
+
+- `maxNavIndex` — navigation cannot go past the accepted doctor. If `acceptedIndex !== null`, `maxNavIndex = acceptedIndex`, otherwise `totalRows - 1`.
+- `hasAccepted` — `acceptedIndex !== null`
+- `allRejected` — no acceptance and every explored index is `'rejected'`
+
+---
+
+## Business rules implemented
+
+### 1. Navigation
+- **Previous / Next** buttons navigate between doctor profiles.
+- Navigation is **capped** at the accepted doctor's index — you cannot view profiles beyond the accepted one.
+- Pills beyond the cap are rendered with a `pill--locked` style (grey, faded, non-clickable).
+- Progress pills are clickable to jump directly to any navigable profile.
+
+### 2. Single accepted doctor
+- Pressing **Accept** on doctor X:
+  - All other doctors that already have a decision are automatically set to `'rejected'` and their `acceptProperty` is written `false`.
+  - Doctor X is set to `'accepted'` and its `acceptProperty` is written `true`.
+  - Navigation cap is moved to X.
+- Pressing **Reject** on the currently accepted doctor:
+  - Clears `acceptedIndex` → removes the navigation cap.
+  - All doctors become navigable again.
+
+### 3. Decision persistence via PCore
+- Every Accept/Reject writes directly onto the Pega page object:
+  ```ts
+  PCore.createPConnect({
+    options: {
+      pageReference: `caseInfo.content.${embedDataRef}[${index}]`,
+      referenceList: `.${embedDataRef}`,
+    }
+  }).getPConnect().getActionsApi().updateFieldValue(`.acceptProvider`, 'true' | 'false');
+  ```
+- In Storybook (offline), the `try/catch` swallows the call gracefully.
+
+### 4. Visual status
+- A `Status` badge (`Accepted` / `Rejected`) appears in the card header for any profile that has been decided.
+- A summary banner appears at the top once all navigable profiles are decided:
+  - Green `Provider Accepted` if any doctor was accepted.
+  - Red `completionMessage` if all were rejected.
+
+---
+
+## Storybook demo data
+
+Five mock doctors with fields: Name, Specialization, Experience, Hospital, Consultation Fee, Availability, Rating.
+
+The story renders the component alongside an `acceptProvider` log table showing the decision state for each doctor in real time.
+
+---
+
+## How to run locally
+
+```bash
+cd constellation-ui-gallery
+npm install
+npm run start        # starts Storybook on http://localhost:6006
+```
+
+Navigate to **Templates → Page List Swiper** in Storybook.
+
+No external services are required. The Map component has an offline guard that displays a placeholder when no ArcGIS API key is provided.
+
+---
+
+## External connections in this repo (for reference)
+
+| Component | Service | Required? |
+|-----------|---------|-----------|
+| `Pega_Extensions_Map` | ArcGIS CDN | No — guarded with offline placeholder |
+| `Pega_Extensions_ChatGenAI` | `localhost:8000` GenAI backend | No — only active in a live Pega environment |
+| `Pega_Extensions_OAuthConnect` | OAuth provider | No — only active in a live Pega environment |
+| All components | Pega Platform server | No — mocked via `window.PCore` in Storybook stories |

--- a/src/components/Pega_Extensions_Map/demo.stories.tsx
+++ b/src/components/Pega_Extensions_Map/demo.stories.tsx
@@ -190,6 +190,31 @@ export const Default: Story = {
         };
       },
     };
+    if (!args.apiKey) {
+      return (
+        <div
+          style={{
+            padding: '2rem',
+            border: '1px dashed #888',
+            borderRadius: '8px',
+            color: '#555',
+            textAlign: 'center',
+            height: args.height || '20rem',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            flexDirection: 'column',
+            gap: '0.5rem',
+          }}
+        >
+          <strong>Map component (offline mode)</strong>
+          <span>
+            This component requires ArcGIS CDN (<code>js.arcgis.com</code>). Provide an{' '}
+            <code>apiKey</code> in the controls panel to enable it.
+          </span>
+        </div>
+      );
+    }
     return <PegaExtensionsMap {...props}></PegaExtensionsMap>;
   },
   args: {

--- a/src/components/Pega_Extensions_PageListSwiper/Docs.mdx
+++ b/src/components/Pega_Extensions_PageListSwiper/Docs.mdx
@@ -1,0 +1,35 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title='Templates/Page List Swiper' />
+
+# Page List Swiper
+
+Renders pages from a **page list** one at a time as a card. The user can **Accept** or **Reject** each page to move to the next one. When all pages have been reviewed, a summary is shown.
+
+## Use Case
+
+Ideal for workflows where a user must individually review and decide on items in a list — for example, approving/rejecting doctor profiles, candidate resumes, job applications, product requests, etc.
+
+## How It Works
+
+1. The component reads a **page list** configured in Region A. Each field added to Region A must be backed by a `ScalarList` (i.e., a list property such as `.Doctors[].pyName`).
+2. All fields share the same index — field index 0 is shown on card 1, index 1 on card 2, and so on.
+3. Clicking **Accept** or **Reject** advances to the next page and records the decision.
+4. A color-coded progress bar at the top tracks reviewed vs. pending pages.
+5. On completion a summary badge row shows totals.
+
+## Props
+
+| Prop                | Type     | Default                  | Description                                              |
+|---------------------|----------|--------------------------|----------------------------------------------------------|
+| `heading`           | `string` | `"Review Profiles"`      | Title displayed above the swiper                         |
+| `acceptLabel`       | `string` | `"Accept"`               | Label for the accept (positive) action button            |
+| `rejectLabel`       | `string` | `"Reject"`               | Label for the reject (negative) action button            |
+| `completionMessage` | `string` | `"All profiles reviewed"`| Message shown when all pages have been reviewed          |
+
+## Configuring in Pega Designer
+
+1. Add the **Page List Swiper** template to a view.
+2. In **Region A**, add fields from an embedded page list (e.g. `.Doctors[].pyName`, `.Doctors[].pySpecialization`).
+3. Each field's property path must follow the `@FILTERED_LIST .PageList[].PropertyName` pattern so the component can extract parallel value arrays.
+4. Optionally override `heading`, `acceptLabel`, `rejectLabel`, and `completionMessage` via inherited props.

--- a/src/components/Pega_Extensions_PageListSwiper/config.json
+++ b/src/components/Pega_Extensions_PageListSwiper/config.json
@@ -1,0 +1,62 @@
+{
+    "name": "Pega_Extensions_PageListSwiper",
+    "label": "Page List Swiper",
+    "description": "Displays pages from a page list one at a time, allowing the user to accept or reject each page before proceeding to the next.",
+    "organization": "Pega",
+    "version": "4.0.0",
+    "library": "Extensions",
+    "allowedApplications": [],
+    "componentKey": "Pega_Extensions_PageListSwiper",
+    "type": "Template",
+    "subtype": "DETAILS",
+    "properties": [
+        {
+            "name": "A",
+            "label": "Region A",
+            "format": "CONTENTPICKER",
+            "addTypeList": [
+                "Fields"
+            ],
+            "allowCreatingGroup": false
+        },
+        {
+            "name": "heading",
+            "label": "Heading",
+            "format": "TEXT",
+            "defaultValue": "Review Profiles"
+        },
+        {
+            "name": "acceptLabel",
+            "label": "Accept button label",
+            "format": "TEXT",
+            "defaultValue": "Accept"
+        },
+        {
+            "name": "rejectLabel",
+            "label": "Reject button label",
+            "format": "TEXT",
+            "defaultValue": "Reject"
+        },
+        {
+            "name": "completionMessage",
+            "label": "Completion message",
+            "format": "TEXT",
+            "defaultValue": "All profiles reviewed"
+        },
+        {
+            "format": "LABEL",
+            "label": "About",
+            "name": "PegaAboutLabel",
+            "variant": "h3"
+        },
+        {
+            "format": "LABEL",
+            "label": "Pega_Extensions 4.0.0",
+            "name": "PegaAboutData",
+            "variant": "primary"
+        }
+    ],
+    "buildDate": "2026-06-04T00:00:00.000Z",
+    "infinityVersion": "25.1.0",
+    "packageCosmosVersion": "8.21.5"
+}

--- a/src/components/Pega_Extensions_PageListSwiper/demo.stories.tsx
+++ b/src/components/Pega_Extensions_PageListSwiper/demo.stories.tsx
@@ -1,0 +1,237 @@
+import { useState, useEffect } from 'react';
+import type { StoryObj } from '@storybook/react-webpack5';
+import { PegaExtensionsPageListSwiper } from './index';
+
+type configInfo = {
+  value?: Array<any>;
+  componentType?: string;
+  label?: string;
+};
+
+type info = {
+  config: configInfo;
+  type: string;
+  children?: Array<info>;
+  getPConnect?: () => any;
+};
+
+export default {
+  title: 'Templates/Page List Swiper',
+  argTypes: {
+    getPConnect: {
+      table: { disable: true },
+    },
+  },
+  component: PegaExtensionsPageListSwiper,
+};
+
+/* ─── Demo data: a list of 5 doctor profiles ─────────────────────────────── */
+
+const doctorFields: Array<info> = [
+  {
+    config: {
+      value: ['Dr. Alice Nguyen', 'Dr. Bob Martinez', 'Dr. Carol Smith', 'Dr. David Lee', 'Dr. Eva Brown'],
+      componentType: 'TextInput',
+      label: 'Name',
+    },
+    type: 'ScalarList',
+  },
+  {
+    config: {
+      value: ['Cardiology', 'Neurology', 'Pediatrics', 'Orthopedics', 'Dermatology'],
+      componentType: 'TextInput',
+      label: 'Specialization',
+    },
+    type: 'ScalarList',
+  },
+  {
+    config: {
+      value: ['12 years', '8 years', '20 years', '15 years', '5 years'],
+      componentType: 'TextInput',
+      label: 'Experience',
+    },
+    type: 'ScalarList',
+  },
+  {
+    config: {
+      value: ['City General Hospital', 'Neuro Care Clinic', "St. Mary's Children Hospital", 'Bone & Joint Center', 'SkinHealth Institute'],
+      componentType: 'TextInput',
+      label: 'Hospital',
+    },
+    type: 'ScalarList',
+  },
+  {
+    config: {
+      value: ['$250 / visit', '$300 / visit', '$180 / visit', '$220 / visit', '$200 / visit'],
+      componentType: 'TextInput',
+      label: 'Consultation Fee',
+    },
+    type: 'ScalarList',
+  },
+  {
+    config: {
+      value: ['Mon–Fri, 9am–5pm', 'Tue–Sat, 10am–6pm', 'Mon–Wed, 8am–4pm', 'Mon–Fri, 11am–7pm', 'Thu–Sun, 9am–3pm'],
+      componentType: 'TextInput',
+      label: 'Availability',
+    },
+    type: 'ScalarList',
+  },
+  {
+    config: {
+      value: ['4.9 ★', '4.7 ★', '4.8 ★', '4.6 ★', '4.5 ★'],
+      componentType: 'TextInput',
+      label: 'Rating',
+    },
+    type: 'ScalarList',
+  },
+];
+
+/* ─── Mock PCore & PConnect ─────────────────────────────────────────────────── */
+
+const genDemoView = () => {
+  const demoView: any = {
+    name: 'demoView',
+    type: 'View',
+    config: {
+      template: 'PageListSwiper',
+      ruleClass: 'Work-',
+      inheritedProps: { label: 'Doctor Profiles' },
+    },
+    children: [
+      {
+        name: 'A',
+        type: 'Region',
+        children: doctorFields,
+        getPConnect: () => ({
+          getRawMetadata: () => demoView.children[0],
+        }),
+      },
+    ],
+    classID: 'Work-MyComponents',
+  };
+  return demoView;
+};
+
+const setPCore = (onAcceptProperty: (index: number, value: string) => void) => {
+  (window as any).PCore = {
+    getLocaleUtils: () => ({
+      getLocaleValue: (val: string) => val,
+    }),
+    getContextTreeManager: () => ({
+      addPageListNode: () => {},
+    }),
+    createPConnect: (config: any) => ({
+      getPConnect: () => ({
+        getActionsApi: () => ({
+          updateFieldValue: (prop: string, value: string) => {
+            /* Extract the array index from pageReference: "...Doctors[2]" → 2 */
+            const match = (config?.options?.pageReference ?? '').match(/\[(\d+)\]$/);
+            const idx = match ? parseInt(match[1], 10) : -1;
+            console.log(`Doctor[${idx}]${prop} =`, value);
+            onAcceptProperty(idx, value);
+          },
+        }),
+        getContextName: () => '',
+      }),
+    }),
+  };
+};
+
+/* ─── Story ─────────────────────────────────────────────────────────────────── */
+
+type Story = StoryObj<typeof PegaExtensionsPageListSwiper>;
+
+const DOCTOR_NAMES = ['Dr. Alice Nguyen', 'Dr. Bob Martinez', 'Dr. Carol Smith', 'Dr. David Lee', 'Dr. Eva Brown'];
+
+export const Default: Story = {
+  render: (args) => {
+    const demoView = genDemoView();
+
+    /* Track acceptProvider writes: index → 'true' | 'false' */
+    const [providerLog, setProviderLog] = useState<Array<{ index: number; value: string }>>([]);
+
+    useEffect(() => {
+      setPCore((index, value) => {
+        setProviderLog((prev) => {
+          /* Replace existing entry for same index, or append */
+          const next = prev.filter((e) => e.index !== index);
+          return [...next, { index, value }];
+        });
+      });
+    }, []);
+
+    const getPConnect = () => ({
+      meta: { name: '' },
+      options: { viewName: '' },
+      getLocalizedValue: (val: string) => val,
+      getContextName: () => 'workarea',
+      getTarget: () => 'workarea',
+      getActionsApi: () => ({
+        updateFieldValue: (_key: string, value: string) => {
+          console.log('Decision recorded:', value);
+        },
+      }),
+      getChildren: () => demoView.children,
+      getRawMetadata: () => demoView,
+      getInheritedProps: () => demoView.config.inheritedProps,
+      setInheritedProp: () => {},
+      setValue: () => {},
+      /* Return pageref so embedDataRef is resolved for the PCore createPConnect call */
+      resolveConfigProps: (f: any) => ({ ...f, pageref: 'Doctors' }),
+    });
+
+    return (
+      <div style={{ maxWidth: '600px', margin: '2rem auto' }}>
+        <PegaExtensionsPageListSwiper {...args} getPConnect={getPConnect} />
+
+        {/* acceptProvider log panel */}
+        {providerLog.length > 0 && (
+          <div
+            style={{
+              marginTop: '1.5rem',
+              padding: '1rem',
+              background: '#f8f8f8',
+              border: '1px solid #e0e0e0',
+              borderRadius: '8px',
+              fontFamily: 'monospace',
+              fontSize: '0.875rem',
+            }}
+          >
+            <strong>acceptProvider values (written to doctor page objects):</strong>
+            <table style={{ width: '100%', marginTop: '0.5rem', borderCollapse: 'collapse' }}>
+              <thead>
+                <tr style={{ textAlign: 'left', borderBottom: '1px solid #ddd' }}>
+                  <th style={{ padding: '0.25rem 0.5rem' }}>Doctor</th>
+                  <th style={{ padding: '0.25rem 0.5rem' }}>acceptProvider</th>
+                  <th style={{ padding: '0.25rem 0.5rem' }}>Decision</th>
+                </tr>
+              </thead>
+              <tbody>
+                {providerLog
+                  .sort((a, b) => a.index - b.index)
+                  .map((entry) => (
+                    <tr key={entry.index} style={{ borderBottom: '1px solid #f0f0f0' }}>
+                      <td style={{ padding: '0.25rem 0.5rem' }}>{DOCTOR_NAMES[entry.index] ?? `Profile ${entry.index + 1}`}</td>
+                      <td style={{ padding: '0.25rem 0.5rem', color: entry.value === 'true' ? '#2e844a' : '#c23934' }}>
+                        {entry.value}
+                      </td>
+                      <td style={{ padding: '0.25rem 0.5rem' }}>
+                        {entry.value === 'true' ? '✅ Accepted' : '❌ Rejected'}
+                      </td>
+                    </tr>
+                  ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    );
+  },
+  args: {
+    heading: 'Review Doctor Profiles',
+    acceptLabel: 'Accept',
+    rejectLabel: 'Reject',
+    completionMessage: 'All doctor profiles reviewed!',
+    acceptProperty: 'acceptProvider',
+  },
+};

--- a/src/components/Pega_Extensions_PageListSwiper/index.tsx
+++ b/src/components/Pega_Extensions_PageListSwiper/index.tsx
@@ -1,0 +1,295 @@
+/**
+ * Pega_Extensions_PageListSwiper
+ *
+ * Renders pages from a page list one at a time.
+ * Each page is shown as a card with all its fields displayed.
+ * The user can Accept or Reject the current page to move to the next one.
+ *
+ * Accepted / rejected indices are reported back to Pega via updateFieldValue.
+ */
+
+import { useState, useEffect } from 'react';
+import {
+  withConfiguration,
+  Text,
+  Button,
+  Flex,
+  Card,
+  CardContent,
+  CardHeader,
+  Status,
+  Progress,
+} from '@pega/cosmos-react-core';
+import StyledPageListSwiper from './styles';
+import '../shared/create-nonce';
+
+/* ─── Types ─────────────────────────────────────────────────────────────────── */
+
+export type PageListSwiperProps = {
+  getPConnect: any;
+  heading?: string;
+  acceptLabel?: string;
+  rejectLabel?: string;
+  completionMessage?: string;
+  /** Property name on each page list item that stores the yes/no accept decision */
+  acceptProperty?: string;
+};
+
+type FieldDef = {
+  label: string;
+  value: Array<any>;
+  componentType?: string;
+};
+
+type FieldsResult = {
+  fields: FieldDef[];
+  embedDataRef: string;
+};
+
+/* ─── Utility: extract parallel ScalarList fields from the region children ─── */
+
+function getAllFields(getPConnect: any): FieldsResult {
+  const metadata = getPConnect().getRawMetadata();
+  if (!metadata?.children) return { fields: [], embedDataRef: '' };
+
+  const region = metadata.children[0];
+  const children: Array<any> = region?.children ?? [];
+
+  let embedDataRef = '';
+
+  const fields = children
+    .filter((child: any) => child.config != null)
+    .map((child: any): FieldDef | null => {
+      const cfg = child.config;
+      // String path from Pega: "@FILTERED_LIST .Doctors[].pyName"
+      if (typeof cfg.value === 'string') {
+        const dotIdx = cfg.value.indexOf(' .');
+        const bracketIdx = cfg.value.indexOf('[].'); 
+        if (!embedDataRef && dotIdx !== -1 && bracketIdx !== -1) {
+          embedDataRef = cfg.value.substring(dotIdx + 2, bracketIdx);
+        }
+        const resolved = getPConnect().resolveConfigProps(cfg);
+        return {
+          label: cfg.label ?? '',
+          value: Array.isArray(resolved.value) ? resolved.value : [],
+          componentType: cfg.componentType,
+        };
+      }
+      // Pre-resolved array (Storybook demo)
+      if (Array.isArray(cfg.value)) {
+        const resolved = getPConnect().resolveConfigProps(cfg);
+        if (!embedDataRef && resolved.pageref) embedDataRef = resolved.pageref;
+        return {
+          label: cfg.label ?? '',
+          value: cfg.value as Array<any>,
+          componentType: cfg.componentType,
+        };
+      }
+      return null;
+    })
+    .filter(Boolean) as FieldDef[];
+
+  return { fields, embedDataRef };
+}
+
+/* ─── Component ─────────────────────────────────────────────────────────────── */
+
+export const PegaExtensionsPageListSwiper = (props: PageListSwiperProps) => {
+  const {
+    getPConnect,
+    heading = 'Review Profiles',
+    acceptLabel = 'Accept',
+    rejectLabel = 'Reject',
+    completionMessage = 'All profiles reviewed',
+    acceptProperty = 'acceptProvider',
+  } = props;
+
+  const [fields, setFields] = useState<FieldDef[]>([]);
+  const [embedDataRef, setEmbedDataRef] = useState('');
+  const [currentIndex, setCurrentIndex] = useState(0);
+  /** Per-index record of decisions; allows revisiting and changing decisions */
+  const [decisions, setDecisions] = useState<Record<number, 'accepted' | 'rejected'>>({});
+  /** Index of the currently accepted doctor; null if none accepted */
+  const [acceptedIndex, setAcceptedIndex] = useState<number | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const totalRows = fields.length > 0 ? fields[0].value.length : 0;
+  const currentDecision = decisions[currentIndex];
+  /** Cannot navigate past the accepted doctor */
+  const maxNavIndex = acceptedIndex !== null ? acceptedIndex : totalRows - 1;
+  const hasAccepted = acceptedIndex !== null;
+  const allRejected =
+    !hasAccepted &&
+    totalRows > 0 &&
+    Array.from({ length: totalRows }, (_, i) => i).every((i) => decisions[i] === 'rejected');
+
+  useEffect(() => {
+    const { fields: loadedFields, embedDataRef: loadedRef } = getAllFields(getPConnect);
+    setFields(loadedFields);
+    setEmbedDataRef(loadedRef);
+    setLoading(false);
+  }, [getPConnect]);
+
+  /** Write the yes/no acceptProperty directly onto the doctor's page object */
+  const writeAcceptProperty = (index: number, value: 'true' | 'false') => {
+    try {
+      const messageConfig = {
+        meta: props,
+        options: {
+          context: getPConnect().getContextName(),
+          hasForm: true,
+          pageReference: `caseInfo.content.${embedDataRef}[${index}]`,
+          referenceList: `.${embedDataRef}`,
+          viewName: getPConnect().options?.viewName ?? '',
+        },
+      };
+      const c11nEnv = (window as any).PCore.createPConnect(messageConfig);
+      c11nEnv.getPConnect().getActionsApi().updateFieldValue(`.${acceptProperty}`, value);
+    } catch {
+      /* no-op in Storybook / offline mode */
+    }
+  };
+
+  const handleDecision = (decision: 'accepted' | 'rejected') => {
+    if (decision === 'accepted') {
+      /* Only one accepted doctor allowed at a time.
+         Auto-reject every other already-explored doctor. */
+      const newDecisions: Record<number, 'accepted' | 'rejected'> = {};
+      Object.entries(decisions).forEach(([key, val]) => {
+        const idx = Number(key);
+        if (idx !== currentIndex) {
+          newDecisions[idx] = 'rejected';
+          if (val === 'accepted') writeAcceptProperty(idx, 'false'); // clear old acceptance
+        }
+      });
+      newDecisions[currentIndex] = 'accepted';
+      writeAcceptProperty(currentIndex, 'true');
+      setDecisions(newDecisions);
+      setAcceptedIndex(currentIndex);
+    } else {
+      /* Rejecting: if this was the accepted doctor, lift the nav cap */
+      const wasAccepted = acceptedIndex === currentIndex;
+      if (wasAccepted) setAcceptedIndex(null);
+      setDecisions((prev) => ({ ...prev, [currentIndex]: 'rejected' }));
+      writeAcceptProperty(currentIndex, 'false');
+      /* Auto-advance unless already at the navigation limit */
+      const newMax = wasAccepted ? totalRows - 1 : maxNavIndex;
+      if (currentIndex < newMax) {
+        setCurrentIndex((prev) => prev + 1);
+      }
+    }
+  };
+
+  const handleNavigation = (dir: 'prev' | 'next') => {
+    setCurrentIndex((prev) =>
+      dir === 'prev' ? Math.max(0, prev - 1) : Math.min(maxNavIndex, prev + 1)
+    );
+  };
+
+  /* ── Loading state ── */
+  if (loading) {
+    return <Progress placement='local' message='Loading profiles...' />;
+  }
+
+  /* ── Empty state ── */
+  if (totalRows === 0) {
+    return (
+      <Card>
+        <CardContent>
+          <Text variant='secondary'>No profiles to review.</Text>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  /* ── Profile card (all navigation and decisions happen inline) ── */
+  return (
+    <StyledPageListSwiper>
+      <Flex container={{ direction: 'column', gap: 1 }}>
+        {/* Header bar */}
+        <Text variant='h2'>{heading}</Text>
+
+        {/* All-decided summary banner */}
+        {(hasAccepted || allRejected) && (
+          <div className={`summary-banner summary-banner--${hasAccepted ? 'success' : 'urgent'}`}>
+            {hasAccepted
+              ? <Status variant='success'>Provider Accepted</Status>
+              : <Status variant='urgent'>{completionMessage}</Status>
+            }
+          </div>
+        )}
+
+        {/* Prev / Next navigation row */}
+        <Flex container={{ direction: 'row', alignItems: 'center', justify: 'between' }}>
+          <Button
+            variant='secondary'
+            disabled={currentIndex === 0}
+            onClick={() => handleNavigation('prev')}
+          >← Previous</Button>
+          <Text variant='secondary'>{currentIndex + 1} / {totalRows}</Text>
+          <Button
+            variant='secondary'
+            disabled={currentIndex >= maxNavIndex}
+            onClick={() => handleNavigation('next')}
+          >Next →</Button>
+        </Flex>
+
+        {/* Progress pills — clickable to jump; locked beyond the accepted doctor */}
+        <Flex container={{ direction: 'row', gap: 0.5 }} className='progress-pills'>
+          {Array.from({ length: totalRows }, (_, i) => {
+            const locked = i > maxNavIndex;
+            return (
+              <span
+                key={i}
+                title={locked ? 'Locked' : `Profile ${i + 1}${decisions[i] ? ` — ${decisions[i]}` : ''}`}
+                className={`pill pill--${locked ? 'locked' : (decisions[i] ?? (i === currentIndex ? 'current' : 'pending'))} ${i === currentIndex ? 'pill--active' : ''}`}
+                onClick={() => !locked && setCurrentIndex(i)}
+              />
+            );
+          })}
+        </Flex>
+
+        {/* Profile card */}
+        <Card>
+          <CardHeader>
+            <Flex container={{ direction: 'row', alignItems: 'center', gap: 1 }}>
+              <Text variant='h3'>Profile {currentIndex + 1}</Text>
+              {currentDecision === 'accepted' && <Status variant='success'>Accepted</Status>}
+              {currentDecision === 'rejected' && <Status variant='urgent'>Rejected</Status>}
+            </Flex>
+          </CardHeader>
+          <CardContent>
+            <Flex container={{ direction: 'column', gap: 1 }}>
+              {fields.map((field) => (
+                <Flex
+                  key={field.label}
+                  container={{ direction: 'row', gap: 1, alignItems: 'baseline' }}
+                  className='field-row'
+                >
+                  <Text variant='secondary' className='field-label'>{field.label}</Text>
+                  <Text className='field-value'>{String(field.value[currentIndex] ?? '—')}</Text>
+                </Flex>
+              ))}
+            </Flex>
+          </CardContent>
+        </Card>
+
+        {/* Action buttons — Reject is red, Accept is primary blue */}
+        <Flex container={{ direction: 'row', gap: 1, justify: 'end' }}>
+          <span className='btn-reject-wrapper'>
+            <Button
+              variant='secondary'
+              onClick={() => handleDecision('rejected')}
+            >{rejectLabel}</Button>
+          </span>
+          <Button
+            variant='primary'
+            onClick={() => handleDecision('accepted')}
+          >{acceptLabel}</Button>
+        </Flex>
+      </Flex>
+    </StyledPageListSwiper>
+  );
+};
+
+export default withConfiguration(PegaExtensionsPageListSwiper);

--- a/src/components/Pega_Extensions_PageListSwiper/styles.ts
+++ b/src/components/Pega_Extensions_PageListSwiper/styles.ts
@@ -1,0 +1,109 @@
+import styled, { css } from 'styled-components';
+
+export default styled.div(() => {
+  return css`
+    /* All-decided summary banner */
+    .summary-banner {
+      display: flex;
+      align-items: center;
+      padding: 0.5rem 0.75rem;
+      border-radius: 0.25rem;
+    }
+
+    .summary-banner--success {
+      background-color: #f3faf5;
+    }
+
+    .summary-banner--urgent {
+      background-color: #fff5f5;
+    }
+
+    /* Progress pills row */
+    .progress-pills {
+      flex-wrap: wrap;
+    }
+
+    .pill {
+      display: inline-block;
+      height: 0.375rem;
+      flex: 1 1 1.5rem;
+      border-radius: 0.25rem;
+      min-width: 1rem;
+      max-width: 3rem;
+      cursor: pointer;
+      transition: background-color 0.2s ease, transform 0.1s ease;
+
+      &:hover {
+        transform: scaleY(1.6);
+      }
+    }
+
+    .pill--active {
+      transform: scaleY(1.6);
+    }
+
+    .pill--pending {
+      background-color: #e0e0e0;
+    }
+
+    .pill--current {
+      background-color: #0070d2;
+    }
+
+    .pill--accepted {
+      background-color: #2e844a;
+    }
+
+    .pill--rejected {
+      background-color: #c23934;
+    }
+
+    .pill--locked {
+      background-color: #e0e0e0;
+      opacity: 0.4;
+      cursor: not-allowed;
+
+      &:hover {
+        transform: none;
+      }
+    }
+
+    /* Field rows inside the profile card */
+    .field-row {
+      border-bottom: 0.0625rem solid #f0f0f0;
+      padding: 0.375rem 0;
+
+      &:last-child {
+        border-bottom: none;
+      }
+    }
+
+    .field-label {
+      min-width: 10rem;
+      font-weight: 600;
+    }
+
+    .field-value {
+      flex: 1;
+    }
+
+    /* Reject button — override to red/destructive */
+    .btn-reject-wrapper button {
+      background-color: #c23934;
+      border-color: #c23934;
+      color: #ffffff;
+
+      &:hover,
+      &:focus {
+        background-color: #a31f1a;
+        border-color: #a31f1a;
+        color: #ffffff;
+      }
+
+      &:active {
+        background-color: #8a1915;
+        border-color: #8a1915;
+      }
+    }
+  `;
+});


### PR DESCRIPTION
- New PageListSwiper component renders a pagelist one profile at a time
- Accept / Reject buttons write decision to acceptProperty on each page object
- Single-acceptance rule: accepting a doctor auto-rejects all others explored
- Navigation capped at accepted doctor index; profiles beyond it are locked
- Prev/Next navigation with clickable progress pills
- Per-card Accepted/Rejected status badge for easy identification on revisit
- Summary banner when all navigable profiles are decided
- Red reject button styling via styled-components override
- Full Storybook story with 5 mock doctor profiles and acceptProvider log
- Map component: offline guard to skip ArcGIS CDN when no API key
- context.md: session context and architecture notes
- OVERVIEW.md: repo-level documentation