### PR TITLE
Actionable button - Save call not triggered in certain scenario

### DIFF
--- a/src/components/Pega_Extensions_ActionableButton/index.tsx
+++ b/src/components/Pega_Extensions_ActionableButton/index.tsx
@@ -17,7 +17,7 @@ export const PegaExtensionsActionableButton = (props: ActionableButtonProps) => 
     const actionName = targetAction?.name || label;
     const LaunchLocalAction = async () => {
       const actionsAPI = getPConnect().getActionsApi();
-      if (getPConnect().getContainerName() === 'workarea') {
+      if (getPConnect().getContextName().indexOf('workarea') !== -1) {
         await actionsAPI.saveAssignment(getPConnect().getContextName());
       }
       const openLocalAction = actionsAPI.openLocalAction.bind(actionsAPI);


### PR DESCRIPTION
In hierarchical form and containerName from pconnect is showing primary instead of workarea